### PR TITLE
Enabling k6 and PODs autoscaling modifications

### DIFF
--- a/.github/workflows/k6-update.yaml
+++ b/.github/workflows/k6-update.yaml
@@ -1,0 +1,42 @@
+name: azure-vote-front
+on:
+  push:
+    branches:
+      - loadtest
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  registryName: "natzkadevcontainerregistry"
+  natzkaacr-service-principal-id: "d7820fe3-a20e-4d77-a3a1-76acb2517254"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - uses: azure/k8s-set-context@v1
+      id: set-kubectl-context
+      with:
+         kubeconfig: ${{ secrets.KUBECONFIG_K6_ITEMIS_INT }}
+
+    - name: Deploy apps
+      if: ${{ github.ref == 'refs/heads/loadtest' }}
+      run: |
+        kubectl --namespace default delete configmap k6-load-test-js
+        kubectl --namespace default create configmap k6-load-test-js --from-file k6/load-test.js --output yaml
+        kubectl --namespace default apply -f k6/k6.yaml
+
+    - uses: azure/k8s-set-context@v1
+      id: set-kubectl-context
+      with:
+         kubeconfig: ${{ secrets.KUBECONFIG }}
+
+    - name: Deploy apps
+      if: ${{ github.ref == 'refs/heads/loadtest' }}
+      run: |
+        kubectl apply -f k8s/hpa.yaml

--- a/azure-vote-all-in-one-redis.yaml
+++ b/azure-vote-all-in-one-redis.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: azure-vote-back
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: azure-vote-back
@@ -22,11 +22,11 @@ spec:
         - containerPort: 80
         resources:
           requests:
-            cpu: 100m
-            # memory: 200Mi
+            cpu: 300m
+            memory: 2Gi
           limits:
-            cpu: 500m
-            # memory: 2Gi
+            cpu: 1500m
+            memory: 10Gi
 ---
 apiVersion: v1
 kind: Service
@@ -43,7 +43,7 @@ kind: Deployment
 metadata:
   name: azure-vote-front
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: azure-vote-front
@@ -67,11 +67,11 @@ spec:
         - containerPort: 80
         resources:
           requests:
-            cpu: 50m
+            cpu: 300m
             # memory: 200Mi
           limits:
-            cpu: 500m
-            # memory: 2Gi
+            cpu: 1
+            memory: 2Gi
         env:
         - name: COMPUTING_BK
           value: "http://azure-vote-back"

--- a/k6/k6.yaml
+++ b/k6/k6.yaml
@@ -1,0 +1,27 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: k6-predictive-scaling
+spec:
+  schedule: "*/30 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: k6
+            image: natzkadevcontainerregistry.azurecr.io/k6:prom
+            imagePullPolicy: Always
+            command: ["/usr/bin/k6"]
+            args: ["run", "/mnt/load-test.js", "-o", "output-prometheus-remote"]
+            env:
+              - name: K6_PROMETHEUS_REMOTE_URL
+                value: "https://predscaling01-prom.natzkalabs.com/api/v1/write"
+            volumeMounts:
+            - mountPath: /mnt
+              name: k6-load-test-js
+          volumes:
+          - name: k6-load-test-js
+            configMap:
+              name: k6-load-test-js
+          restartPolicy: OnFailure

--- a/k6/load-test.js
+++ b/k6/load-test.js
@@ -2,7 +2,7 @@ import http from 'k6/http';
 import { sleep } from 'k6';
 
 export const options = {
-    vus: 1000,
+    vus: 100,
     duration: '10m',
 };
 
@@ -20,7 +20,7 @@ function randomExponential(rate, randomUniform) {
 }
 
 export default function () {
-    var url = 'https://predscaling01.natzkalabs.com/loads/matrixinverse?msize=10000';     
+    var url = 'https://predscaling01.natzkalabs.com/loads/matrixinverse?msize=1000';     
     http.get(url);
-    sleep(randomExponential(1))
+    sleep(randomExponential(10))
 }

--- a/k8s/helm.md
+++ b/k8s/helm.md
@@ -19,7 +19,11 @@ helm upgrade --install cert-manager jetstack/cert-manager --namespace ingress --
 
 ## KEDA
 helm repo add kedacore https://kedacore.github.io/charts
-helm update --install keda kedacore/keda --namespace ingress-nginx
+helm update --install keda kedacore/keda --namespace ingress
+
+## LINKERD and LINKERD-VIZ
+linkerd install | kubectl apply -f -
+helm upgrade --install --namespace linkerd-viz --create-namespace linkerd-viz linkerd/linkerd-viz -f k8s/linkerd-viz.yaml
 
 <!-- 
 ## kubed 

--- a/k8s/hpa.yaml
+++ b/k8s/hpa.yaml
@@ -1,0 +1,39 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: prometheus-azure-vote-back
+  namespace: default
+spec:
+  scaleTargetRef:
+    name: azure-vote-back
+  pollingInterval: 5
+  cooldownPeriod:  30
+  minReplicaCount: 2
+  maxReplicaCount: 6
+  advanced:
+    # restoreToOriginalReplicaCount: true
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 30
+          # policies:
+          # - type: Percent
+          #   value: 100
+          #   periodSeconds: 15
+  triggers:
+  - type: prometheus
+    metadata:
+      serverAddress: http://prometheus-stack-kube-prom-prometheus.monitoring.svc.cluster.local:9090
+      metricName: number_of_requests
+      threshold: '2'
+      query: sum(rate(request_total{app="azure-vote-back"}[1m]))
+      # query: sum(rate(nginx_ingress_controller_requests{ingress="azure-vote-front", status="200"}[5m]))*100
+  - type: cpu
+    metadata:
+      type: AverageValue
+      value: "500m"
+  # - type: memory
+  #   metadata:
+  #     type: AverageValue
+  #     value: "75"
+  

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -31,6 +31,7 @@ metadata:
   namespace: monitoring
   labels:
     app: nginx-ingress
+    release: prometheus-stack
 spec:
   endpoints:
   - interval: 10s
@@ -42,45 +43,34 @@ spec:
     matchNames:
     - ingress
 
----
-apiVersion: keda.sh/v1alpha1
-kind: ScaledObject
-metadata:
-  name: prometheus-azure-vote-back
-  namespace: default
-spec:
-  scaleTargetRef:
-    name: azure-vote-back
-  pollingInterval: 5
-  cooldownPeriod:  30
-  minReplicaCount: 1
-  maxReplicaCount: 10
-  advanced:
-    # restoreToOriginalReplicaCount: true
-    horizontalPodAutoscalerConfig:
-      behavior:
-        scaleDown:
-          stabilizationWindowSeconds: 30
-          # policies:
-          # - type: Percent
-          #   value: 100
-          #   periodSeconds: 15
-  triggers:
-  - type: prometheus
-    metadata:
-      serverAddress: http://prometheus-stack-kube-prom-prometheus.monitoring.svc.cluster.local:9090
-      metricName: number_of_requests
-      threshold: '1'
-      query: sum(rate(nginx_ingress_controller_nginx_process_connections[1m]))
-  - type: cpu
-    metadata:
-      type: AverageValue
-      value: "200m"
-  # - type: memory
-  #   metadata:
-  #     type: AverageValue
-  #     value: "75"
+# INGRESS FOR PROMETHEUS AND GRAFANA IS DEPLOYED BY PROMETHEUS HELM CHART
   
+# ---
+
+# apiVersion: autoscaling/v2beta2
+# kind: HorizontalPodAutoscaler
+# metadata:
+#   name: prom-adapter
+#   namespace: default
+# spec:
+#   scaleTargetRef:
+#     apiVersion: apps/v1
+#     kind: Deployment
+#     name: azure-vote-back
+#   minReplicas: 1
+#   maxReplicas: 10
+#   metrics:
+#   - type: Object
+#     object:
+#       metric:
+#         name: nginx_ingress_controller_requests
+#       describedObject:
+#         apiVersion: networking.k8s.io/v1beta1
+#         kind: ingress
+#         name: azure-vote-front
+#       target:
+#         type: Value
+#         value: "1"
 
 # --- 
 # apiVersion: networking.k8s.io/v1

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -51,7 +51,7 @@ metadata:
 spec:
   scaleTargetRef:
     name: azure-vote-back
-  pollingInterval: 15
+  pollingInterval: 5
   cooldownPeriod:  30
   minReplicaCount: 1
   maxReplicaCount: 10
@@ -75,7 +75,7 @@ spec:
   - type: cpu
     metadata:
       type: AverageValue
-      value: "300m"
+      value: "200m"
   # - type: memory
   #   metadata:
   #     type: AverageValue

--- a/k8s/kube-prometheus-stack.yaml
+++ b/k8s/kube-prometheus-stack.yaml
@@ -38,6 +38,8 @@ prometheus:
   prometheusSpec:
     image:
       tag: v2.31.1
+    enableFeatures:
+      - remote-write-receiver
     storageSpec:
       volumeClaimTemplate:
        spec:

--- a/k8s/linkerd-viz.yaml
+++ b/k8s/linkerd-viz.yaml
@@ -1,0 +1,8 @@
+prometheus:
+  enabled: false
+
+grafana:
+  enabled: false
+
+
+prometheusUrl: http://prometheus-stack-kube-prom-prometheus.monitoring.svc.cluster.local:9090


### PR DESCRIPTION
Whenever branch "loadtest" is updated, the changes will automatically deploy k6 and hpa changes.
Added some other minor changes like enabling prometheus to accept k6 output or adjusting cpu/memory for the app frontend and backend. 